### PR TITLE
No remote lookup if its a local dist

### DIFF
--- a/lib/PPM/Make.pm
+++ b/lib/PPM/Make.pm
@@ -82,7 +82,7 @@ sub make_ppm {
       print "Found a local distribution: $local_dist\n";
       my $basename = basename($local_dist);
       copy($local_dist, File::Spec->catfile($build_dir, $basename));
-      $self->{search}->{no_remote_lookup} = 0;
+      $self->{search}->{no_remote_lookup} = 1; 
     }
 
     die $self->{fetch_error} 


### PR DESCRIPTION
Hi charsbar,

I'm not sure if it's wanted or if it's a bug. When I have got a local dist, there is no information for a remote look up.

Thank you. 

Best regards
onefloid